### PR TITLE
fix: containerize hackt and act-utils

### DIFF
--- a/act-utils/Dockerfile
+++ b/act-utils/Dockerfile
@@ -1,0 +1,34 @@
+ARG POETRY_VERSION=1.1.15
+ARG PYTHON_TAG="3.11.1-slim"
+
+FROM python:${PYTHON_TAG} as base
+WORKDIR /act-utils
+
+FROM base as build
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    curl
+
+RUN --mount=type=cache,target=/root/.cache \
+    curl -sSL https://install.python-poetry.org | POETRY_VERSION=${POETRY_VERSION} python3 -
+
+ENV PATH /root/.local/bin:$PATH
+
+COPY act-utils/pyproject.toml .
+COPY act-utils/poetry.lock .
+RUN --mount=type=cache,target=/root/.cache \
+    poetry config virtualenvs.in-project true \
+    && poetry install --no-root
+
+COPY act-utils/ACT ./ACT
+RUN --mount=type=cache,target=/root/.cache \
+    poetry install
+
+FROM base as release
+
+COPY --from=build /act-utils/ACT /act-utils/ACT
+COPY --from=build /act-utils/.venv /act-utils/.venv
+
+WORKDIR /app
+ENTRYPOINT ["/act-utils/.venv/bin/act"]

--- a/act-utils/README.md
+++ b/act-utils/README.md
@@ -42,19 +42,20 @@ which should create the following files:
 
 ```./hacdump.sh -h``` prints the usage.
 
-## ACT.Inspect
-This Python module visualizes the simulation dumps created by _hacdump.sh_. 
+## Visualizing the results
+The Python package `ACT` visualizes the simulation dumps created by _hacdump.sh_. 
 
-
-To use it, launch a Python shell and:
-```python
-import ACT.Inspect as insp
-
-insp.ShowStateTransition('<process.dot>', '<traces.out.events>', '<traces.out.states>', '<traces.out.map>')
+First build the _docker_ image (from repo root):
+```shell
+docker build -f act-utils/Dockerfile -t act-utils .
 ```
 
-Right now, the module works only with HSE simulations.
-![Sample frame from animation](./images/ACT_Inspect_static_demo.png?raw=true "ACT.Inspect.ShowStateTransition() output")
+Then, run the visualizer with
+```shell
+docker run --rm -it -v /path/to/<process>.hac:/app act-utils [--plot | --step [--window WINDOW]] /app/<process>
+```
+ 
+`--plot` will save plots of the event transitions to `.png`. \
+`--step` will open an interactive browser session to step through events one at a time.
 
-During the visualization, latest event node is highlighted with the darkest green. As events progress (and time as well), nodes that are not visited fade away. The number inside a node tells how many times that event has occured.
-The states of various variables (wires) at the latest event is shown at the bottom.
+Run with `--help` for more details.

--- a/hackt_docker/Dockerfile
+++ b/hackt_docker/Dockerfile
@@ -1,30 +1,28 @@
-FROM ubuntu:16.04 as build
+FROM ubuntu:xenial-20210804 as build
 
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get install build-essential automake libtool gawk texinfo -y
+RUN apt-get install build-essential automake libtool gawk texinfo curl -y
 RUN apt-get install gcc-4.7 g++-4.7 libreadline5 libncurses5 libncurses5-dev -y
 
 WORKDIR /hackt/build
-RUN --mount=type=cache,target=/hackt/build \
-    --mount=type=bind,src=hackt_docker/deps,target=/hackt/deps \
+RUN --mount=type=bind,src=hackt_docker/deps,target=/hackt/deps \
     tar -C . -xjf /hackt/deps/bison-2.3.tar.bz2 && \
+    curl -sSL 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' -o bison-2.3/build-aux/config.guess && \
     pushd bison-2.3 && ./configure --prefix=/usr/local && make && make install && popd
 
-RUN --mount=type=cache,target=/hackt/build \
-    --mount=type=bind,src=hackt_docker/deps,target=/hackt/deps \
+RUN --mount=type=bind,src=hackt_docker/deps,target=/hackt/deps \
     tar -C . -xjf /hackt/deps/flex-2.5.4-2-src.tar.bz2 && \
     pushd flex-2.5.4-2 && ./configure --prefix=/usr/local && make && make install && popd
 
 COPY hackt_docker/hackt /hackt/src
 WORKDIR /hackt/src
-RUN --mount=type=cache,target=/hackt/build \
-    ./bootstrap && \
+RUN ./bootstrap && \
     sed -i.orig -e '/link_all_deplibs/s|=no|=yes|' ./config/libtool.m4 && \
     CC=/usr/bin/gcc-4.7 CXX=/usr/bin/g++-4.7 CFLAGS="-O2 -Wno-error" CXXFLAGS="-O2 -Wno-error" ./configure --disable-strict-dialect --disable-docs --prefix=/usr/local && \
     make && make test && make install
 
-FROM ubuntu:16.04
+FROM ubuntu:xenial-20210804 as release
 
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,target=/var/lib/apt,sharing=locked \
@@ -32,3 +30,5 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,t
     && apt install -y libtool texinfo libreadline5 libncurses5
 COPY --from=build /usr/local /usr/local
 COPY act-utils/hacdump.sh /usr/local/bin/
+
+WORKDIR /app


### PR DESCRIPTION
* image is now multi-platform (linux/amd64 and linux/arm64)
* hackt + hacdump.sh is in `hackt` container
* act-utils (including web-based visualizer) is in `act-utils` container